### PR TITLE
fix: link in home page would overflow on mobile

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -21,7 +21,7 @@ export default function Home() {
         Native）开源实习计划由中国科学院软件研究所主办，目标是培养熟悉 RISC-V
         架构和 Rust 编程语言的高校开发者，构建 RISC-V 架构下的云原生技术栈。
       </p>
-      <div className="flex flex-row items-center gap-5">
+      <div className="flex flex-row flex-wrap items-center justify-center gap-5">
         <Link
           href="/docs/student/pre-task"
           className={buttonVariants({ className: "px-6", size: "lg" })}


### PR DESCRIPTION
This PR fixes the issue where the link button on the homepage may overflow on mobile devices, causing it to be difficult to view.

<img width="1200" height="1049" alt="image" src="https://github.com/user-attachments/assets/2450a13d-211f-4d86-8eec-675cae40c808" />
